### PR TITLE
add simple GitHub Actions setup for continuous integration

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,18 @@
+name: Continuous Integration
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  build-images:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: rpi-basic
+        run: make rpi-basic
+
+      - name: rpi-firewall
+        run: make rpi-firewall


### PR DESCRIPTION
Expecting this to fail because qemu will not be setup on the Ubuntu runner.

Calling `make rpi-basic` and `make rpi-firewall` separately is a workaround because our Makefile is still rather naive.  Ideally, `make` would build all the images.  That currently fails because the first image runs `./bootstrap/armv7/destroy --remove` to delete the chroot and the second image target does not know to rebuild the chroot.