### PR TITLE
begin adding tests with ShellSpec

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,15 @@ on:
     branches: [ main ]
 
 jobs:
+  test-scripts:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: test
+        run: make test
+
   build-images:
     runs-on: ubuntu-20.04
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,9 @@
-bootstrap/
-config/*.yaml
+/bootstrap/
+/config/*.yaml
+
+# shellspec
+/shellspec/
+/.shellspec-local
+/.shellspec-quick.log
+/report/
+/coverage/

--- a/.shellspec
+++ b/.shellspec
@@ -1,0 +1,12 @@
+--require spec_helper
+
+## Default kcov (coverage) options
+# --kcov-options "--include-path=. --path-strip-level=1"
+# --kcov-options "--include-pattern=.sh"
+# --kcov-options "--exclude-pattern=/.shellspec,/spec/,/coverage/,/report/"
+
+## Example: Include script "myprog" with no extension
+# --kcov-options "--include-pattern=.sh,myprog"
+
+## Example: Only specified files/directories
+# --kcov-options "--include-pattern=myprog,/lib/"

--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,15 @@ ALPINE_VERSION := 3.14
 APORTS_REPO := https://github.com/alpinelinux/aports.git
 BUILD_USER := imagebuilder
 WORK_DIR := bootstrap
+SHELLSPEC_DIR := shellspec
+SHELLSPEC_REPO := https://github.com/shellspec/shellspec.git
+SHELLSPEC_TAG := 0.28.1
 
 
 all: build-images
+
+test: $(SHELLSPEC_DIR)/shellspec
+	$(SHELLSPEC_DIR)/shellspec
 
 clean:
 ifneq ($(wildcard $(WORK_DIR)/armv7),)
@@ -78,6 +84,9 @@ clone-aports:
 ifeq ($(wildcard $(WORK_DIR)/shared/aports/.git),)
 	git clone --depth 1 $(APORTS_REPO) $(WORK_DIR)/shared/aports
 endif
+
+$(SHELLSPEC_DIR)/shellspec:
+	git -c advice.detachedHead=false clone --depth 1 -b $(SHELLSPEC_TAG) $(SHELLSPEC_REPO) $(SHELLSPEC_DIR)
 
 # Insert `--allow-untrusted` into the init script used to boostrap the live system
 # from the initramfs.  Useful for debugging errors...like why `/etc/inittab` is missing.

--- a/scripts/shared.sh
+++ b/scripts/shared.sh
@@ -39,7 +39,7 @@ add_ssh_key() {
     if [ -n "$HL_SSH_KEY_URL" ]; then
         mkdir --mode=0700 "$tmp"/root/.ssh
 
-        curl --max-time 10 -o "$tmp"/root/.ssh/authorized_keys "$HL_SSH_KEY_URL"
+        curl --max-time 10 "$HL_SSH_KEY_URL" > "$tmp"/root/.ssh/authorized_keys
         chmod 0400 "$tmp"/root/.ssh/authorized_keys
     fi
 }

--- a/spec/scripts/shared_spec.sh
+++ b/spec/scripts/shared_spec.sh
@@ -1,0 +1,41 @@
+Describe 'shared.sh'
+  Describe 'initialization'
+    Include ./scripts/shared.sh
+
+    It 'defines $tmp'
+      The variable tmp should be defined
+      The variable tmp should start with "/tmp/tmp."
+    End
+
+    It 'creates $tmp directory'
+      The path $tmp should be directory
+    End
+  End
+
+  Describe 'add_ssh_key'
+    Include ./scripts/shared.sh
+
+    It 'always creates /root directory'
+      When call add_ssh_key
+      The path $tmp/root should be directory
+    End
+
+    It 'does not create .ssh directory without HL_SSH_KEY_URL defined'
+      HL_SSH_KEY_URL=""
+      When call add_ssh_key
+      The path $tmp/root/.ssh should not be exist
+    End
+
+    curl() {
+        echo "ssh-rsa AAAAB3Nza= foo@bar.com"
+    }
+
+    It 'creates .ssh/authorized_key file with HL_SSH_KEY_URL defined'
+      HL_SSH_KEY_URL="https://somehost/foo.pub"
+      When call add_ssh_key
+      The path $tmp/root/.ssh should be exist
+      The path $tmp/root/.ssh/authorized_keys should be file
+      The contents of file  $tmp/root/.ssh/authorized_keys should equal "ssh-rsa AAAAB3Nza= foo@bar.com"
+    End
+  End
+End

--- a/spec/spec_helper.sh
+++ b/spec/spec_helper.sh
@@ -1,0 +1,24 @@
+# shellcheck shell=sh
+
+# Defining variables and functions here will affect all specfiles.
+# Change shell options inside a function may cause different behavior,
+# so it is better to set them here.
+# set -eu
+
+# This callback function will be invoked only once before loading specfiles.
+spec_helper_precheck() {
+  # Available functions: info, warn, error, abort, setenv, unsetenv
+  # Available variables: VERSION, SHELL_TYPE, SHELL_VERSION
+  : minimum_version "0.28.1"
+}
+
+# This callback function will be invoked after a specfile has been loaded.
+spec_helper_loaded() {
+  :
+}
+
+# This callback function will be invoked after core modules has been loaded.
+spec_helper_configure() {
+  # Available functions: import, before_each, after_each, before_all, after_all
+  : import 'support/custom_matcher'
+}


### PR DESCRIPTION
Use [ShellSpec] to make assertions about expected behavior.  Starting with coverage of `scripts/shared.sh` but anticipate expanding to the `scripts/genapkovl-*` in later commits.

Added most of the new files with:

    ./shellspec/shellspec --init git

Eventually want the GitHub workflow to run on PRs, but holding off until I can do further research and confirm GitHub secrets cannot be exposed with malicious specs.

[ShellSpec]: https://shellspec.info/