### PR TITLE
rpi-firewall: add (3) more network zones: vwif, ata, and voip

### DIFF
--- a/scripts/genapkovl-rpi-basic.sh
+++ b/scripts/genapkovl-rpi-basic.sh
@@ -2,7 +2,9 @@
 
 hostname="$1"
 
-source "$(dirname "$0")/shared.sh"
+basedir="$(dirname "$0")"
+[ "$basedir" = "/bin" ] && basedir="./scripts" # shellspec workaround for $0 handling
+source "$basedir"/shared.sh
 
 configure_installed_packages() {
 	apk_add \

--- a/scripts/genapkovl-rpi-firewall.sh
+++ b/scripts/genapkovl-rpi-firewall.sh
@@ -2,7 +2,9 @@
 
 hostname="$1"
 
-source "$(dirname "$0")/shared.sh"
+basedir="$(dirname "$0")"
+[ "$basedir" = "/bin" ] && basedir="./scripts" # shellspec workaround for $0 handling
+source "$basedir"/shared.sh
 
 configure_installed_packages() {
 	apk_add \
@@ -79,6 +81,9 @@ EOF
 	add_vlan_interface 102 172.22.2  ; add_vlan_dns_and_dhcp 102 172.22.2  dmz 0
 	add_vlan_interface 103 172.22.3  ; add_vlan_dns_and_dhcp 103 172.22.3  swif
 	add_vlan_interface 104 172.22.4  ; add_vlan_dns_and_dhcp 104 172.22.4  gwif
+	add_vlan_interface 105 172.22.5  ; add_vlan_dns_and_dhcp 105 172.22.5  vwif
+	add_vlan_interface 111 172.22.11 ; add_vlan_dns_and_dhcp 111 172.22.11 ata 0
+	add_vlan_interface 112 172.22.12 ; add_vlan_dns_and_dhcp 112 172.22.12 voip 0
 	add_vlan_interface 113 172.22.13 ; add_vlan_dns_and_dhcp 113 172.22.13 mgmt 0
 	add_vlan_interface 118 172.22.18 ; add_vlan_dns_and_dhcp 118 172.22.18 k8s 0
 }
@@ -131,6 +136,12 @@ iface wg0 inet static
 	# route dmz traffic over VPN
 	post-up /usr/local/bin/vpn_routes add dmz_net 102 "{{ .vpn.int_ip }}"
 	pre-down /usr/local/bin/vpn_routes del dmz_net 102
+	# route vwifi traffic over VPN
+	post-up /usr/local/bin/vpn_routes add vwif_net 105 "{{ .vpn.int_ip }}"
+	pre-down /usr/local/bin/vpn_routes del vwif_net 105
+	# route voip traffic over VPN
+	post-up /usr/local/bin/vpn_routes add voip_net 112 "{{ .vpn.int_ip }}"
+	pre-down /usr/local/bin/vpn_routes del voip_net 112
 	# route k8s traffic over VPN
 	post-up /usr/local/bin/vpn_routes add k8s_net 118 "{{ .vpn.int_ip }}"
 	pre-down /usr/local/bin/vpn_routes del k8s_net 118

--- a/spec/scripts/genapkovl-rpi-firewall_spec.sh
+++ b/spec/scripts/genapkovl-rpi-firewall_spec.sh
@@ -1,0 +1,61 @@
+Describe 'genapkovl-rpi-firewall_spec.sh'
+  # mock chown calls or tests will fail when not run as root
+  chown() {
+      true
+  }
+
+  Include ./scripts/genapkovl-rpi-firewall.sh
+
+  Describe 'add_vlan_interface'
+
+    It 'adds interface stanza in /etc/network/interfaces'
+      Path network-interfaces="$tmp/etc/network/interfaces"
+      When call add_vlan_interface 105 172.22.5
+      The path network-interfaces should be exist
+      The contents of file network-interfaces should include "auto eth0.105
+iface eth0.105 inet static
+	address 172.22.5.1
+	netmask 255.255.255.0"
+    End
+  End
+
+  Describe 'add_vlan_dns_and_dhcp'
+    Path dnsmasq-conf-vwif="$tmp/etc/dnsmasq.d/1050_vwif.conf"
+    Path dnsmasq-conf-voip="$tmp/etc/dnsmasq.d/1120_voip.conf"
+
+    It 'should bind dnsmasq to expected interface'
+      When call add_vlan_dns_and_dhcp 105 172.22.5 vwif
+      The path dnsmasq-conf-vwif should be exist
+      The contents of file dnsmasq-conf-vwif should include "interface=eth0.105
+bind-interfaces"
+    End
+
+    It 'should enable dhcp'
+      When call add_vlan_dns_and_dhcp 105 172.22.5 vwif
+      The path dnsmasq-conf-vwif should be exist
+      The contents of file dnsmasq-conf-vwif should include "dhcp-range=172.22.5.100,172.22.5.149,12h"
+    End
+
+    It 'should enable set ntp server dhcp option'
+      When call add_vlan_dns_and_dhcp 105 172.22.5 vwif
+      The path dnsmasq-conf-vwif should be exist
+      The contents of file dnsmasq-conf-vwif should include "dhcp-option=42,172.22.5.1"
+    End
+
+    It 'should use static keyword when dhcp flag is off'
+      When call add_vlan_dns_and_dhcp 112 172.22.12 voip 0
+      The path dnsmasq-conf-voip should be exist
+      The contents of file dnsmasq-conf-voip should include "dhcp-range=172.22.12.0,static"
+    End
+  End
+
+  Describe 'configure_wireguard'
+    Path vpn-routes="$tmp/usr/local/bin/vpn_routes"
+
+    It 'creates /usr/local/bin/vpn_routes'
+      When call configure_wireguard
+      The path vpn-routes should be exist
+      The path vpn-routes should be executable
+    End
+  End
+End


### PR DESCRIPTION
"vwif" is for a wifi SSID where all traffic is routed over the VPN.
"ata" is for VoIP analog telephone adapters.
"voip" is for VoIP clients like telephone handsets.

Includes several ShellSpec tests for `genapkovl-rpi-firewall_spec.sh`.