### PR TITLE
do not lint the `scripts/mkimg.*.sh` scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ SHELLSPEC_TAG := 0.28.1
 all: build-images
 
 lint:
-	shellcheck scripts/*.sh
+	shellcheck scripts/shared.sh scripts/genapkovl-*.sh
 
 test: $(SHELLSPEC_DIR)/shellspec
 	$(SHELLSPEC_DIR)/shellspec


### PR DESCRIPTION
There is not much code in those scripts and they are not particularly easy to lint with shellcheck because of the way Alpine's mkimage.sh works.