### PR TITLE
bors: begin setting up bors-ng bot

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,7 @@ name: Continuous Integration
 
 on:
   push:
-    branches: [ main ]
+    branches: [main, staging, trying]
 
 jobs:
   test-scripts:

--- a/bors.toml
+++ b/bors.toml
@@ -1,0 +1,4 @@
+status = [
+  "test-scripts",
+  "build-images"
+]


### PR DESCRIPTION
Initial setup per https://bors.tech/documentation/getting-started/ .  Might still need to configure builds of PRs.