### PR TITLE
rename CI workflow from "Continuous Integration" to "CI"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: Continuous Integration
+name: CI
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # bfritz homelab bootstrap scripts
 
 <!-- badges -->
-![continuous integration status](https://github.com/bfritz/homelab-bootstrap/actions/workflows/ci.yaml/badge.svg)
+[![continuous integration status](https://github.com/bfritz/homelab-bootstrap/actions/workflows/ci.yaml/badge.svg)](https://github.com/bfritz/homelab-bootstrap/actions/workflows/ci.yaml)
 [![Bors enabled](https://bors.tech/images/badge_small.svg)](https://app.bors.tech/repositories/38911)
 
 Build scripts that use [qemu] and [alpine-chroot-install] to create custom


### PR DESCRIPTION
Will shorten the name on the "Actions" tab here:
![ci_name](https://user-images.githubusercontent.com/70307/139513096-57ca6693-9429-4b86-93f1-70da5733a60a.png)

and in the badge here:
![ci_badge](https://user-images.githubusercontent.com/70307/139513110-d8134011-b093-49ba-bad2-746645d81831.png)
