### PR TITLE
k0s-worker: upgrade from version 1.22.2+k0s.1 to 1.22.2+k0s.2

### DIFF
--- a/scripts/genapkovl-k0s-worker.sh
+++ b/scripts/genapkovl-k0s-worker.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 
 K0S_ARCH=amd64
-K0S_VER=1.22.2+k0s.1
+K0S_VER=1.22.2+k0s.2
 K0S_URL="https://github.com/k0sproject/k0s/releases/download/v$K0S_VER/k0s-v$K0S_VER-$K0S_ARCH"
 
 hostname="$1"


### PR DESCRIPTION
Release notes:
https://github.com/k0sproject/k0s/releases/tag/v1.22.2%2Bk0s.2 .