### PR TITLE
k0s: add `argocd_launch_apps` target to bootstrap apps in cluster

### DIFF
--- a/k0s/Makefile
+++ b/k0s/Makefile
@@ -20,6 +20,7 @@ kubeconfig := cluster_kubeconf.yaml
 	argocd_cli_login \
 	argocd_find_initial_admin_password \
 	argocd_find_service_name \
+	argocd_launch_apps \
 	__end
 
 all:
@@ -80,6 +81,9 @@ argocd_find_initial_admin_password: argocd_find_service_name
 
 argocd_find_service_name:
 	$(eval ARGOCD_SVC := $(shell kubectl --kubeconfig $(kubeconfig) -n argocd get service -l 'app.kubernetes.io/name=argocd-server' -o name))
+
+argocd_launch_apps:
+	ssh root@$(shell cd $(mkfile_dir); ./tf_controller_ip.sh) mkdir -p /var/lib/k0s/manifests/apps \&\& curl -sLo /var/lib/k0s/manifests/apps/apps.yaml https://raw.githubusercontent.com/bfritz/homelab-apps/main/apps.yaml
 
 
 __end:

--- a/k0s/README.md
+++ b/k0s/README.md
@@ -11,6 +11,7 @@ Usage:
     make provision_controller
     # optional: make install_k0sctl    # to install x86_64 copy of k0sctl on build host
     make build_cluster
+    make argocd_launch_apps
 
 
 [1gb "nanode" instance]: https://www.linode.com/pricing/#compute-shared

--- a/k0s/cluster.yaml.in
+++ b/k0s/cluster.yaml.in
@@ -42,3 +42,7 @@ spec:
                 dex:
                   enabled: false
               namespace: argocd
+            - name: argo-cd-applicationset
+              chartname: argo-repo/argocd-applicationset
+              version: "1.6.0"
+              namespace: argocd


### PR DESCRIPTION
Running the new `argocd_launch_apps` target will deploy an `ApplicationSet` manifest from
<https://github.com/bfritz/homelab-apps/blob/main/apps.yaml> into k0s using its [manifest deployer].

The `ApplicationSet` tells Argo CD to deploy any apps it finds under <https://github.com/bfritz/homelab-apps/tree/main/apps> to kickoff the gitops management of the applications in the cluster.

[manifest deployer]: https://docs.k0sproject.io/v1.22.2+k0s.2/manifests/