### PR TITLE
k0s: run Argo CD server with `--insecure` flag to support ingress

### DIFF
--- a/k0s/cluster.yaml.in
+++ b/k0s/cluster.yaml.in
@@ -37,10 +37,13 @@ spec:
             charts:
             - name: argo-cd
               chartname: argo-repo/argo-cd
-              version: "3.26.5"
+              version: "3.26.9"
               values: |
                 dex:
                   enabled: false
+                server:
+                  extraArgs:
+                  - --insecure
               namespace: argocd
             - name: argo-cd-applicationset
               chartname: argo-repo/argocd-applicationset


### PR DESCRIPTION
As [described] in the helm chart, the server needs an `--insecure` flag to allow TLS termination at the ingress.  Without that setting, Ingress into port 80 or port 443 of the server results in an infinite HTTP 307 redirect loop.

Similar to https://github.com/argoproj/argo-cd/issues/3169 , but configuring the URL as `https://argocd.k8s` was insufficient.

It's possible the insecure flag would not be needed if the `server.certificate.domain` value [is set].

Also updated to the latest release of the Helm chart.  That was just opportunistic maintenance, not a requirement for the fix.

[described]: https://github.com/argoproj/argo-helm/blob/argo-cd-3.26.9/charts/argo-cd/templates/NOTES.txt#L13-L15
[is set]: https://github.com/argoproj/argo-helm/blob/argo-cd-3.26.9/charts/argo-cd/values.yaml#L793-L797