### PR TITLE
k0s: upgrade Argo CD to 2.1.9 after CVE-2022-24348

### DIFF
--- a/k0s/cluster.yaml.in
+++ b/k0s/cluster.yaml.in
@@ -37,8 +37,11 @@ spec:
             charts:
             - name: argo-cd
               chartname: argo-repo/argo-cd
-              version: "3.26.11"
+              version: "3.28.1"
               values: |
+                global:
+                  image:
+                    tag: "v2.1.9"
                 dex:
                   enabled: false
                 server:
@@ -47,5 +50,8 @@ spec:
               namespace: argocd
             - name: argo-cd-applicationset
               chartname: argo-repo/argocd-applicationset
-              version: "1.6.0"
+              version: "1.9.1"
               namespace: argocd
+              values: |
+                image:
+                  tag: "v0.3.0"


### PR DESCRIPTION
Upgrade to the latest release of Argo CD 2.1.x to fix a path traversal but that would allow users with the ability to create `Application`s to exfil secrets.  More at:
https://github.com/argoproj/argo-cd/security/advisories/GHSA-63qx-x74g-jcr7

Also upgrade to the latest release of the `ApplicationSet` controller, v0.3.0, and be explicit about its version.