### PR TITLE
rpi-basic rpi-firewall: workaround aports RPi build breakage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ export ACI_REPO := https://github.com/alpinelinux/alpine-chroot-install.git
 export ACI_TAG := v0.13.2
 export ALPINE_VERSION := 3.15
 export APORTS_REPO := https://github.com/alpinelinux/aports.git
+export APORTS_COMMIT := 9a782440~1
 export BUILD_USER := imagebuilder
 export WORK_DIR := bootstrap
 

--- a/Makefile.images
+++ b/Makefile.images
@@ -77,8 +77,12 @@ endif
 
 clone-aports:
 ifeq ($(wildcard $(WORK_DIR)/shared/aports/.git),)
-	git clone --depth 1 $(APORTS_REPO) $(WORK_DIR)/shared/aports
+	git clone --shallow-since=2022-01-15 $(APORTS_REPO) $(WORK_DIR)/shared/aports
 endif
+# Rewind before https://gitlab.alpinelinux.org/alpine/aports/-/commit/9a782440682903971ea57c457135531d26c6d7ab
+# caused `gzip: invalid magic` error during `rpi_blobs` step in `mkimage-armv7`.
+	$(info Checking out aports commit $(APORTS_COMMIT) prior to rpi_blobs breakage.)
+	@git --git-dir="$(WORK_DIR)/shared/aports/.git" checkout $(APORTS_COMMIT) > /dev/null
 
 # Insert `--allow-untrusted` into the init script used to boostrap the live system
 # from the initramfs.  Useful for debugging errors...like why `/etc/inittab` is missing.


### PR DESCRIPTION
The aports change in [commit 9a78244] seems to have broken the `mkimg.sh` builds for Raspberry Pi profiles, at least under `arch-chroot-install`.

After that commit, see this error in our builds:

    bootstrap/armv7/enter-chroot -u imagebuilder \
            /home/brad/projects/infra/alpine-homelab-bootstrap/bootstrap/shared/aports/scripts/mkimage.sh \
            --arch armv7 \
            --profile rpi_basic \
            --outdir /home/brad/projects/infra/alpine-homelab-bootstrap/bootstrap/shared \
            --repository https://dl-cdn.alpinelinux.org/alpine/v3.15/main \
            --extra-repository https://dl-cdn.alpinelinux.org/alpine/v3.15/community
    OK: 0 MiB in 0 packages
    fetch https://dl-cdn.alpinelinux.org/alpine/v3.15/main/armv7/APKINDEX.tar.gz
    fetch https://dl-cdn.alpinelinux.org/alpine/v3.15/community/armv7/APKINDEX.tar.gz
    v3.15.0-258-gd5d32e35cf [https://dl-cdn.alpinelinux.org/alpine/v3.15/main]
    v3.15.0-256-g047dab5823 [https://dl-cdn.alpinelinux.org/alpine/v3.15/community]
    OK: 15419 distinct packages available
    >>> mkimage-armv7: Building rpi_basic
    >>> mkimage-armv7: --> rpi_config efccd2fd6481f8406afef352868b4480ae4b6652
    >>> mkimage-armv7: --> rpi_blobs
    gzip: invalid magic
    /bin/tar: Child returned status 1
    /bin/tar: Error is not recoverable: exiting now

[First failing build](https://github.com/bfritz/homelab-bootstrap/runs/5067297232?check_suite_focus=true) was on Feb 5.  [Previous build](https://github.com/bfritz/homelab-bootstrap/actions/runs/1700720616), on Jan 15, completed without issue.

[commit 9a78244]: https://gitlab.alpinelinux.org/alpine/aports/-/commit/9a782440682903971ea57c457135531d26c6d7ab