### PR TITLE
k0s: upgrade Argo CD from 2.1.9 to to 2.2.5

### DIFF
--- a/k0s/cluster.yaml.in
+++ b/k0s/cluster.yaml.in
@@ -37,11 +37,11 @@ spec:
             charts:
             - name: argo-cd
               chartname: argo-repo/argo-cd
-              version: "3.28.1"
+              version: "3.33.3"
               values: |
                 global:
                   image:
-                    tag: "v2.1.9"
+                    tag: "v2.2.5"
                 dex:
                   enabled: false
                 server:


### PR DESCRIPTION
Changelog at:
https://github.com/argoproj/argo-cd/blob/master/CHANGELOG.md

Release notes at:
https://github.com/argoproj/argo-cd/releases/tag/v2.2.5