### PR TITLE
rpi-basic rpi-firewall: better document `raspberrypi-bootloader-common` breakage

### DIFF
--- a/Makefile.images
+++ b/Makefile.images
@@ -81,6 +81,7 @@ ifeq ($(wildcard $(WORK_DIR)/shared/aports/.git),)
 endif
 # Rewind before https://gitlab.alpinelinux.org/alpine/aports/-/commit/9a782440682903971ea57c457135531d26c6d7ab
 # caused `gzip: invalid magic` error during `rpi_blobs` step in `mkimage-armv7`.
+# Can likely be removed after upgrade to 3.16 (once it is released).
 	$(info Checking out aports commit $(APORTS_COMMIT) prior to rpi_blobs breakage.)
 	@git --git-dir="$(WORK_DIR)/shared/aports/.git" checkout $(APORTS_COMMIT) > /dev/null
 


### PR DESCRIPTION
Follow-up to #39 to note that the hack in that PR can be removed after 3.16 is released and we upgrade.

The [change] that broke the build includes this diff:

```diff
-       apk fetch --quiet --stdout raspberrypi-bootloader | tar -C "${DESTDIR}" -zx --strip=1 boot/
+       for i in raspberrypi-bootloader-common raspberrypi-bootloader; do
+               apk fetch --quiet --stdout "$i" | tar -C "${DESTDIR}" -zx --strip=1 boot/ || return 1
+       done
```

We run that in a 3.15 chroot, but `raspberrypi-bootloader-common` is currently just in edge.  That means the `apk fetch` fails:

    $ apk fetch raspberrypi-bootloader-common
    raspberrypi-bootloader-common: unable to select package (or its dependencies)

In the context of the `tar` pipeline above, that triggers the error that broke our previous builds:

    gzip: invalid magic
    /bin/tar: Child returned status 1
    /bin/tar: Error is not recoverable: exiting now

[change]: https://gitlab.alpinelinux.org/alpine/aports/-/commit/9a782440682903971ea57c457135531d26c6d7ab