### PR TITLE
k0s: upgrade Argo CD from 2.2.5 to to 2.3.2

### DIFF
--- a/k0s/Makefile
+++ b/k0s/Makefile
@@ -1,4 +1,4 @@
-ARGOCD_VER := 2.1.6
+ARGOCD_VER := 2.3.2
 ARGOCD_CLI_URL := https://github.com/argoproj/argo-cd/releases/download/v$(ARGOCD_VER)/argocd-linux-amd64
 
 K0SCTL_VER := 0.12.2

--- a/k0s/cluster.yaml.in
+++ b/k0s/cluster.yaml.in
@@ -36,22 +36,15 @@ spec:
               url: https://argoproj.github.io/argo-helm
             charts:
             - name: argo-cd
+              namespace: argocd
               chartname: argo-repo/argo-cd
-              version: "3.33.3"
+              version: "4.2.2"
               values: |
                 global:
                   image:
-                    tag: "v2.2.5"
+                    tag: "v2.3.2"
                 dex:
                   enabled: false
                 server:
                   extraArgs:
                   - --insecure
-              namespace: argocd
-            - name: argo-cd-applicationset
-              chartname: argo-repo/argocd-applicationset
-              version: "1.9.1"
-              namespace: argocd
-              values: |
-                image:
-                  tag: "v0.3.0"


### PR DESCRIPTION
ApplicationSet is now part of argo-cd proper and enabled by default.

Changelog at:
https://github.com/argoproj/argo-cd/blob/master/CHANGELOG.md

Release notes at:
https://github.com/argoproj/argo-cd/releases/tag/v2.3.2