### PR TITLE
k0s, k0s-worker: upgrade from version 1.23.1+k0s.1 to 1.23.5+k0s.0

### DIFF
--- a/k0s/cluster.yaml.in
+++ b/k0s/cluster.yaml.in
@@ -17,7 +17,7 @@ spec:
     role: worker
 {{- end }}
   k0s:
-    version: 1.23.1+k0s.1
+    version: 1.23.5+k0s.0
     config:
       apiVersion: k0s.k0sproject.io/v1beta1
       kind: Cluster

--- a/scripts/genapkovl-k0s-worker.sh
+++ b/scripts/genapkovl-k0s-worker.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 
 K0S_ARCH=amd64
-K0S_VER=1.23.1+k0s.1
+K0S_VER=1.23.5+k0s.0
 K0S_URL="https://github.com/k0sproject/k0s/releases/download/v$K0S_VER/k0s-v$K0S_VER-$K0S_ARCH"
 
 hostname="$1"


### PR DESCRIPTION
Release notes:
https://github.com/k0sproject/k0s/releases/tag/v1.23.5%2Bk0s.0
https://github.com/k0sproject/k0s/releases/tag/v1.23.3%2Bk0s.1
https://github.com/k0sproject/k0s/releases/tag/v1.23.3%2Bk0s.0