### PR TITLE
rpi-basic: add armhf image for Raspberry Pi Zero

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [rpi-basic, rpi-firewall, k0s-worker]
+        image: [rpi-basic-armhf, rpi-basic-armv7, rpi-firewall, k0s-worker-x86_64]
 
     steps:
       - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@
 /.shellspec-quick.log
 /report/
 /coverage/
+
+# misc
+build*.log
+build*.log.?

--- a/Makefile
+++ b/Makefile
@@ -14,15 +14,18 @@ SHELLSPEC_TAG := 0.28.1
 
 all: build-images
 
-build-images: rpi-basic rpi-firewall k0s-worker
+build-images: rpi-basic-armhf rpi-basic-armv7 rpi-firewall k0s-worker-x86_64
 
-rpi-basic:
-	ARCH=armv7  make -f Makefile.images rpi-basic
+rpi-basic-armhf:
+	ARCH=armhf make -f Makefile.images rpi-basic
+
+rpi-basic-armv7:
+	ARCH=armv7 make -f Makefile.images rpi-basic
 
 rpi-firewall:
 	ARCH=armv7  make -f Makefile.images rpi-firewall
 
-k0s-worker:
+k0s-worker-x86_64:
 	ARCH=x86_64 make -f Makefile.images k0s-worker
 
 lint:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Build scripts that use [qemu] and [alpine-chroot-install] to create custom
 Alpine images that run from RAM.  Images will include:
 
-* [x] rpi-basic - `armv7` image for basic Raspberry Pi 2, 3, or 4 host
+* [x] rpi-basic - `armhf` and `armv7` images for basic Raspberry Pi 0, 2, 3, or 4 host
 * [x] rpi-firewall - `armv7` image to run [awall], [dnsmasq], and [wireguard] on Raspberry Pi 4 as home router
 * [ ] rpi-snapcast - `armhf` image to run [snapcast] on a Raspberry Pi Zero W
 * [x] k0s-worker - `x86_64` image to run as [k0s] worker node
@@ -27,16 +27,16 @@ to expose host metrics.
 
 ### rpi-basic
 
-Image for Raspberry Pi 2, 3, or 4 to act as a basic host.  Mostly used
-for adhoc testing.
+Image for Raspberry Pi Zero, 2, 3, or 4 to act as a basic host.
+Mostly used for adhoc testing.
 
 Pulls dhcp lease on wired interface and runs openssh server. `root`
 user does not have password and the only way to login with ssh is
 with key-based authenticateion.  Set `HL_SSH_KEY_URL` to the URL of
 a [ssh authorized_keys file] to pre-authorize one or more keys.
 
-Runs consoles on `tty1` and `ttyACM0`, the Pi's [built-in serial port].  Boot
-messages are logged to serial console.
+Runs consoles on `tty1` and `ttyACM0`, the Pi's
+[built-in serial port].  Boot messages are logged to serial console.
 
 ### rpi-firewall
 


### PR DESCRIPTION
Also refactor makefile to make room for armv7 or aarch64 build of the k0s-worker image in an upcoming PR.