### PR TITLE
build `rpi-k0s-controller-armv7` in CI and misc cleanup

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [rpi-basic-armhf, rpi-basic-armv7, rpi-firewall, k0s-worker-x86_64]
+        image:
+          - k0s-worker-x86_64
+          - rpi-basic-armhf
+          - rpi-basic-armv7
+          - rpi-firewall-armv7
+          - rpi-k0s-controller-armv7
 
     steps:
       - uses: actions/checkout@v2

--- a/Makefile
+++ b/Makefile
@@ -15,20 +15,20 @@ all: build-images
 
 build-images: rpi-basic-armhf rpi-basic-armv7 rpi-firewall k0s-worker-x86_64
 
+k0s-worker-x86_64:
+	ARCH=x86_64 make -f Makefile.images k0s-worker
+
 rpi-basic-armhf:
 	ARCH=armhf make -f Makefile.images rpi-basic
 
 rpi-basic-armv7:
 	ARCH=armv7 make -f Makefile.images rpi-basic
 
-rpi-firewall:
+rpi-firewall-armv7:
 	ARCH=armv7  make -f Makefile.images rpi-firewall
 
 rpi-k0s-controller-armv7:
 	ARCH=armv7 HL_HOSTNAME=k0s-controller make -f Makefile.images rpi-k0s-controller
-
-k0s-worker-x86_64:
-	ARCH=x86_64 make -f Makefile.images k0s-worker
 
 lint:
 	shellcheck --exclude=SC1090,SC1091 scripts/shared.sh scripts/genapkovl-*.sh

--- a/Makefile.images
+++ b/Makefile.images
@@ -6,7 +6,18 @@ ifneq ($(wildcard $(WORK_DIR)/$(ARCH)),)
 endif
 	rm -rf $(WORK_DIR)
 
-rpi-basic: chroot build-user # chroot-initramfs-hack
+k0s-worker: build-user
+	HL_OVERLAY_DIR=$(abspath $(WORK_DIR))/shared/overlays \
+	$(WORK_DIR)/$(ARCH)/enter-chroot -u $(BUILD_USER) \
+		$(abspath $(WORK_DIR))/shared/aports/scripts/mkimage.sh \
+		--arch $(ARCH) \
+		--profile k0s_worker \
+		--outdir $(abspath $(WORK_DIR))/shared \
+		--repository https://dl-cdn.alpinelinux.org/alpine/v$(ALPINE_VERSION)/main \
+		--extra-repository https://dl-cdn.alpinelinux.org/alpine/v$(ALPINE_VERSION)/community
+	$(WORK_DIR)/$(ARCH)/destroy --remove
+
+rpi-basic: build-user # chroot-initramfs-hack
 	$(WORK_DIR)/$(ARCH)/enter-chroot -u $(BUILD_USER) \
 		$(abspath $(WORK_DIR))/shared/aports/scripts/mkimage.sh \
 		--arch $(ARCH) \
@@ -16,7 +27,7 @@ rpi-basic: chroot build-user # chroot-initramfs-hack
 		--extra-repository https://dl-cdn.alpinelinux.org/alpine/v$(ALPINE_VERSION)/community
 	$(WORK_DIR)/$(ARCH)/destroy --remove
 
-rpi-firewall: chroot build-user # chroot-initramfs-hack
+rpi-firewall: build-user # chroot-initramfs-hack
 	HL_OVERLAY_DIR=$(abspath $(WORK_DIR))/shared/overlays \
 	$(WORK_DIR)/$(ARCH)/enter-chroot -u $(BUILD_USER) \
 		$(abspath $(WORK_DIR))/shared/aports/scripts/mkimage.sh \
@@ -33,17 +44,6 @@ rpi-k0s-controller: build-user
 		$(abspath $(WORK_DIR))/shared/aports/scripts/mkimage.sh \
 		--arch $(ARCH) \
 		--profile rpi_k0s_controller \
-		--outdir $(abspath $(WORK_DIR))/shared \
-		--repository https://dl-cdn.alpinelinux.org/alpine/v$(ALPINE_VERSION)/main \
-		--extra-repository https://dl-cdn.alpinelinux.org/alpine/v$(ALPINE_VERSION)/community
-	$(WORK_DIR)/$(ARCH)/destroy --remove
-
-k0s-worker: build-user
-	HL_OVERLAY_DIR=$(abspath $(WORK_DIR))/shared/overlays \
-	$(WORK_DIR)/$(ARCH)/enter-chroot -u $(BUILD_USER) \
-		$(abspath $(WORK_DIR))/shared/aports/scripts/mkimage.sh \
-		--arch $(ARCH) \
-		--profile k0s_worker \
 		--outdir $(abspath $(WORK_DIR))/shared \
 		--repository https://dl-cdn.alpinelinux.org/alpine/v$(ALPINE_VERSION)/main \
 		--extra-repository https://dl-cdn.alpinelinux.org/alpine/v$(ALPINE_VERSION)/community


### PR DESCRIPTION
Add CI build for new Raspberry Pi k0s controller image.  Should have been part of PR #47.

Also various organization and cleanup tasks in the Makefiles.  Targets are better alphabetized now and `chroot` target dependency is removed where not needed.