### PR TITLE
rpi-snapcast-client: add Raspberry Pi Zero image to stream audio

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,6 +32,7 @@ jobs:
           - rpi-basic-armv7
           - rpi-firewall-armv7
           - rpi-k0s-controller-armv7
+          - rpi-snapcast-client-armhf
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,6 +38,10 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: build ${{ matrix.image }}
+        env:
+          # from `wpa_passphrase test_essid supersecret`
+          HL_WIFI_SSID: "test_essid"
+          HL_WIFI_PSK: "40faa8d23b3cf02b10e0f06cd69e179dfad59db25761909c3ecfdaa49bad53d0"
         run: make ${{ matrix.image }}
 
       - name: list-images-content

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,9 @@ rpi-firewall-armv7:
 rpi-k0s-controller-armv7:
 	ARCH=armv7 HL_HOSTNAME=k0s-controller make -f Makefile.images rpi-k0s-controller
 
+rpi-snapcast-client-armhf:
+	ARCH=armhf make -f Makefile.images rpi-snapcast-client
+
 lint:
 	shellcheck --exclude=SC1090,SC1091 scripts/shared.sh scripts/genapkovl-*.sh
 

--- a/Makefile.images
+++ b/Makefile.images
@@ -49,6 +49,16 @@ rpi-k0s-controller: build-user
 		--extra-repository https://dl-cdn.alpinelinux.org/alpine/v$(ALPINE_VERSION)/community
 	$(WORK_DIR)/$(ARCH)/destroy --remove
 
+rpi-snapcast-client: build-user # chroot-initramfs-hack
+	$(WORK_DIR)/$(ARCH)/enter-chroot -u $(BUILD_USER) \
+		$(abspath $(WORK_DIR))/shared/aports/scripts/mkimage.sh \
+		--arch $(ARCH) \
+		--profile rpi_snapcast_client \
+		--outdir $(abspath $(WORK_DIR))/shared \
+		--repository https://dl-cdn.alpinelinux.org/alpine/v$(ALPINE_VERSION)/main \
+		--extra-repository https://dl-cdn.alpinelinux.org/alpine/v$(ALPINE_VERSION)/community
+	$(WORK_DIR)/$(ARCH)/destroy --remove
+
 chroot: clone-aci populate-shared
 	sudo SUDO_USER=$(BUILD_USER) \
 		$(WORK_DIR)/aci/alpine-chroot-install \

--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@
 [![Bors enabled](https://bors.tech/images/badge_small.svg)](https://app.bors.tech/repositories/38911)
 
 Build scripts that use [qemu] and [alpine-chroot-install] to create custom
-Alpine images that run from RAM.  Images will include:
+Alpine images that run from RAM.  Images include:
 
 * [x] k0s-worker - `x86_64` image to run as [k0s] worker node
 * [x] rpi-basic - `armhf` and `armv7` images for basic Raspberry Pi 0, 2, 3, or 4 host
 * [x] rpi-firewall - `armv7` image to run [awall], [dnsmasq], and [wireguard] on Raspberry Pi 4 as home router
-* [ ] rpi-snapcast - `armhf` image to run [snapcast] on a Raspberry Pi Zero W
+* [x] rpi-snapcast-client - `armhf` image to run [snapcast] on a Raspberry Pi Zero W
 * [x] rpi-k0s-controller - `armv7` image to run as [k0s] controller node
 
 These [Alpine Linux] images run on my home network and are rather opinionated.
@@ -62,6 +62,13 @@ Replaces a similar setup with [Seagate DockStar] running [ArchLinux ARM] and
 
 [k0s] controller node for Raspberry Pi 4.  Intended as foundation for
 controllers that will be provisioned with [k0sctl].
+
+### rpi-snapcast-client
+
+Minimal image with the [snapcast] client software installed.  Intended
+to run on Raspberry Pi Zero W connected to amplifer for streaming audio.
+Set `HL_SNAPCAST_SERVER` to the hostname of the snapcast server the
+client should connect to at boot.
 
 
 ## Prior Art and Inspiration

--- a/scripts/genapkovl-rpi-snapcast-client.sh
+++ b/scripts/genapkovl-rpi-snapcast-client.sh
@@ -1,0 +1,99 @@
+#!/bin/sh -e
+
+hostname="$1"
+
+basedir="$(dirname "$0")"
+[ "$basedir" = "/bin" ] && basedir="./scripts" # shellspec workaround for $0 handling
+. "$basedir"/shared.sh
+
+configure_installed_packages() {
+	apk_add \
+		chrony \
+		openssh-server \
+		prometheus-node-exporter \
+		snapcast \
+
+}
+
+configure_network() {
+	mkdir -p "$tmp"/etc/network
+	makefile root:root 0644 "$tmp"/etc/network/interfaces <<EOF
+# ifupdown-ng syntax
+# See https://github.com/ifupdown-ng/ifupdown-ng
+
+auto lo
+iface lo
+	use loopback
+
+auto wlan0
+iface wlan0
+	use dhcp
+EOF
+}
+
+configure_init_scripts() {
+	rc_add devfs sysinit
+	rc_add dmesg sysinit
+	rc_add mdev sysinit
+	rc_add hwdrivers sysinit
+	rc_add modloop sysinit
+
+	rc_add hwclock boot
+	rc_add modules boot
+	rc_add sysctl boot
+	rc_add hostname boot
+	rc_add bootmisc boot
+	rc_add klogd boot
+	rc_add syslog boot
+
+	rc_add mount-ro shutdown
+	rc_add killprocs shutdown
+	rc_add savecache shutdown
+
+	# additional services
+	rc_add chronyd default
+	rc_add sshd default
+	rc_add node-exporter default
+	rc_add snapcast-client default
+}
+
+configure_snapcast() {
+	mkdir -p "$tmp"/etc/conf.d
+	makefile root:root 0644 "$tmp"/etc/conf.d/snapcast-client <<EOF
+# snapclient options
+
+snapclient_opts="-h ${HL_SNAPCAST_SERVER:-snapcast-server.local} -p 31704"
+EOF
+}
+
+configure_syslog() {
+	mkdir -p "$tmp"/etc/conf.d
+	makefile root:root 0644 "$tmp"/etc/conf.d/syslog <<EOF
+# -t         Strip client-generated timestamps
+# -s SIZE    Max size (KB) before rotation (default 200KB, 0=off)
+# -b N       N rotated logs to keep (default 1, max 99, 0=purge)
+
+SYSLOGD_OPTS="-t -s 512 -b 10"
+EOF
+}
+
+tmp="$(mktemp -d)"
+trap cleanup EXIT
+
+mkdir -p "$tmp"/etc
+makefile root:root 0644 "$tmp"/etc/hostname <<EOF
+rpi-snapcast-client
+EOF
+
+configure_network
+configure_wifi
+configure_installed_packages
+configure_chrony_as_client
+configure_syslog
+add_ssh_key
+configure_init_scripts
+configure_snapcast
+install_overlays
+
+echo "Creating overlay file $hostname.apkovl.tar.gz ..."
+tar -C "$tmp" -c etc root | gzip -9n > "$hostname.apkovl.tar.gz"

--- a/scripts/mkimg.rpi-snapcast-client.sh
+++ b/scripts/mkimg.rpi-snapcast-client.sh
@@ -1,0 +1,31 @@
+rpi_snapcast_client_gen_usercfg() {
+	cat <<-EOF
+	gpu_mem=16
+	dtparam=audio=on
+	dtoverlay=hifiberry-dac
+EOF
+}
+
+build_rpi_snapcast_client_usercfg() {
+	rpi_snapcast_client_gen_usercfg > "${DESTDIR}"/usercfg.txt
+}
+
+section_rpi_snapcast_client_usercfg() {
+	[ "$PROFILE" = "rpi_snapcast_client" ] || return 0
+	build_section rpi_snapcast_client_usercfg "$( rpi_snapcast_client_gen_usercfg | checksum )"
+}
+
+profile_rpi_snapcast_client() {
+	profile_rpi
+	kernel_cmdline="console=tty1 $CMDLINE_EXTRA"
+	apks="$apks
+		chrony
+		openssh-server
+		prometheus-node-exporter
+		wireless-tools
+		wpa_supplicant
+		atop
+		snapcast
+"
+	apkovl="genapkovl-rpi-snapcast-client.sh"
+}


### PR DESCRIPTION
Install `snapcast` and configure the `snapcast-client` daemon to
connect to a snapcast server to stream audio from it.  Used as source
for multi-source audio amplifier.

Assumes [HiFiBerry]-compatible DAC is installed to the Raspberry Pi.
Tested with [pHAT DAC].  Edit this section of `usercfg.txt` to use a
different DAC:

    dtparam=audio=on
    dtoverlay=hifiberry-dac

The following configuration variables can be used to customize the
image:

* `HL_WIFI_SSID` - WiFi SSID
* `HL_WIFI_PSK` - WiFi passphrase
* `HL_SNAPCAST_SERVER` - hostname or IP of the snapcast server
* `HL_NTP_SERVER` - NTP server to override the default of `pool.ntp.org`

[HiFiBerry]: https://www.hifiberry.com/dacs
[pHAT DAC]: https://www.adafruit.com/product/3016