### PR TITLE
k0s-worker, rpi-k0s-controller, rpi-basic: allow NTP server override

### DIFF
--- a/scripts/genapkovl-k0s-node.sh
+++ b/scripts/genapkovl-k0s-node.sh
@@ -104,6 +104,7 @@ EOF
 
 configure_network
 configure_installed_packages
+configure_chrony_as_client
 add_ssh_key
 configure_init_scripts
 install_k0s

--- a/scripts/genapkovl-rpi-basic.sh
+++ b/scripts/genapkovl-rpi-basic.sh
@@ -87,6 +87,7 @@ EOF
 configure_network
 log_martians
 configure_installed_packages
+configure_chrony_as_client
 configure_syslog
 add_ssh_key
 configure_init_scripts


### PR DESCRIPTION
If `HL_NTP_SERVER` is set, use its value instead of `pool.ntp.org` for time service.