### PR TITLE
k0s-worker, rpi-k0s-controller, rpi-basic, rpi-snapcast-client: set hostname via DHCP

### DIFF
--- a/scripts/genapkovl-k0s-node.sh
+++ b/scripts/genapkovl-k0s-node.sh
@@ -103,6 +103,7 @@ $hostname
 EOF
 
 configure_network
+set_hostname_with_udhcpc
 configure_installed_packages
 configure_chrony_as_client
 add_ssh_key

--- a/scripts/genapkovl-rpi-basic.sh
+++ b/scripts/genapkovl-rpi-basic.sh
@@ -85,6 +85,7 @@ rpi-basic
 EOF
 
 configure_network
+set_hostname_with_udhcpc
 log_martians
 configure_installed_packages
 configure_chrony_as_client

--- a/scripts/genapkovl-rpi-snapcast-client.sh
+++ b/scripts/genapkovl-rpi-snapcast-client.sh
@@ -87,6 +87,7 @@ EOF
 
 configure_network
 configure_wifi
+set_hostname_with_udhcpc
 configure_installed_packages
 configure_chrony_as_client
 configure_syslog

--- a/scripts/shared.sh
+++ b/scripts/shared.sh
@@ -165,6 +165,17 @@ EOF
     rc_add wpa_supplicant default
 }
 
+
+# DHCP assigned hostname should override hostname in image
+set_hostname_with_udhcpc() {
+    [ -d "$tmp"/etc ] || mkdir --mode=0755 "$tmp"/etc
+    [ -d "$tmp"/etc/udhcpc ] || mkdir --mode=0755 "$tmp"/etc/udhcpc
+    [ -d "$tmp"/etc/udhcpc/post-bound ] || mkdir --mode=0755 "$tmp"/etc/udhcpc/post-bound
+    makefile root:root 0755 "$tmp"/etc/udhcpc/post-bound/hostname <<EOF
+[ -n "\$hostname" ] && hostname "\$hostname"
+EOF
+}
+
 install_overlays() {
     if [ -n "$HL_OVERLAY_DIR" ] && [ -d "$HL_OVERLAY_DIR" ]; then
         for T in "$HL_OVERLAY_DIR"/*.tgz; do


### PR DESCRIPTION

If DHCP server assigns hostname, use it instead of the value baked into the image.