### PR TITLE
rpi-ruuvi: add work-in-progress image for relaying Ruuvi Tag data to InfluxDB

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,6 +32,7 @@ jobs:
           - rpi-basic-armv7
           - rpi-firewall-armv7
           - rpi-k0s-controller-armv7
+          - rpi-ruuvi-armhf
           - rpi-snapcast-client-armhf
 
     steps:

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,9 @@ rpi-firewall-armv7:
 rpi-k0s-controller-armv7:
 	ARCH=armv7 HL_HOSTNAME=k0s-controller make -f Makefile.images rpi-k0s-controller
 
+rpi-ruuvi-armhf:
+	ARCH=armhf make -f Makefile.images rpi-ruuvi
+
 rpi-snapcast-client-armhf:
 	ARCH=armhf make -f Makefile.images rpi-snapcast-client
 

--- a/Makefile.images
+++ b/Makefile.images
@@ -49,6 +49,16 @@ rpi-k0s-controller: build-user
 		--extra-repository https://dl-cdn.alpinelinux.org/alpine/v$(ALPINE_VERSION)/community
 	$(WORK_DIR)/$(ARCH)/destroy --remove
 
+rpi-ruuvi: build-user # chroot-initramfs-hack
+	$(WORK_DIR)/$(ARCH)/enter-chroot -u $(BUILD_USER) \
+		$(abspath $(WORK_DIR))/shared/aports/scripts/mkimage.sh \
+		--arch $(ARCH) \
+		--profile rpi_ruuvi \
+		--outdir $(abspath $(WORK_DIR))/shared \
+		--repository https://dl-cdn.alpinelinux.org/alpine/v$(ALPINE_VERSION)/main \
+		--extra-repository https://dl-cdn.alpinelinux.org/alpine/v$(ALPINE_VERSION)/community
+	$(WORK_DIR)/$(ARCH)/destroy --remove
+
 rpi-snapcast-client: build-user # chroot-initramfs-hack
 	$(WORK_DIR)/$(ARCH)/enter-chroot -u $(BUILD_USER) \
 		$(abspath $(WORK_DIR))/shared/aports/scripts/mkimage.sh \

--- a/README.md
+++ b/README.md
@@ -7,11 +7,12 @@
 Build scripts that use [qemu] and [alpine-chroot-install] to create custom
 Alpine images that run from RAM.  Images include:
 
-* [x] k0s-worker - `x86_64` image to run as [k0s] worker node
-* [x] rpi-basic - `armhf` and `armv7` images for basic Raspberry Pi 0, 2, 3, or 4 host
-* [x] rpi-firewall - `armv7` image to run [awall], [dnsmasq], and [wireguard] on Raspberry Pi 4 as home router
-* [x] rpi-snapcast-client - `armhf` image to run [snapcast] on a Raspberry Pi Zero W
-* [x] rpi-k0s-controller - `armv7` image to run as [k0s] controller node
+* k0s-worker - `x86_64` image to run as [k0s] worker node
+* rpi-basic - `armhf` and `armv7` images for basic Raspberry Pi 0, 2, 3, or 4 host
+* rpi-firewall - `armv7` image to run [awall], [dnsmasq], and [wireguard] on Raspberry Pi 4 as home router
+* rpi-k0s-controller - `armv7` image to run as [k0s] controller node
+* rpi-ruuvi - `armhf` image to listen for [Ruuvi Tag] data on a Raspberry Pi Zero W
+* rpi-snapcast-client - `armhf` image to run [snapcast] on a Raspberry Pi Zero W
 
 These [Alpine Linux] images run on my home network and are rather opinionated.
 No image tarballs are published because it is unlikely they would be generally
@@ -88,6 +89,7 @@ client should connect to at boot.
 [k0s]: https://k0sproject.io/
 [k0sctl]: https://github.com/k0sproject/k0sctl
 [node-exporter]: https://prometheus.io/docs/guides/node-exporter/
+[ruuvi tag]: https://ruuvi.com/ruuvitag/
 [seagate dockstar]: https://www.seagate.com/support/external-hard-drives/network-storage/dockstar/
 [shorewall]: https://shorewall.org/
 [snapcast]: https://github.com/badaix/snapcast#readme

--- a/scripts/genapkovl-rpi-ruuvi.sh
+++ b/scripts/genapkovl-rpi-ruuvi.sh
@@ -1,0 +1,102 @@
+#!/bin/sh -e
+
+RT_LISTENER_URL="https://fewerhassles.com/misc/$ARCH/ruuvitag-listener"
+
+hostname="$1"
+
+basedir="$(dirname "$0")"
+[ "$basedir" = "/bin" ] && basedir="./scripts" # shellspec workaround for $0 handling
+. "$basedir"/shared.sh
+
+configure_installed_packages() {
+	apk_add \
+		chrony \
+		openssh-server \
+		prometheus-node-exporter \
+		bluez \
+
+}
+
+configure_network() {
+	mkdir -p "$tmp"/etc/network
+	makefile root:root 0644 "$tmp"/etc/network/interfaces <<EOF
+# ifupdown-ng syntax
+# See https://github.com/ifupdown-ng/ifupdown-ng
+
+auto lo
+iface lo
+	use loopback
+
+auto wlan0
+iface wlan0
+	use dhcp
+EOF
+}
+
+configure_init_scripts() {
+	rc_add devfs sysinit
+	rc_add dmesg sysinit
+	rc_add mdev sysinit
+	rc_add hwdrivers sysinit
+	rc_add modloop sysinit
+
+	rc_add hwclock boot
+	rc_add modules boot
+	rc_add sysctl boot
+	rc_add hostname boot
+	rc_add bootmisc boot
+	rc_add klogd boot
+	rc_add syslog boot
+
+	rc_add mount-ro shutdown
+	rc_add killprocs shutdown
+	rc_add savecache shutdown
+
+	# additional services
+	rc_add chronyd default
+	rc_add sshd default
+	rc_add node-exporter default
+}
+
+install_ruuvitag_listener() {
+       [ -d "$tmp"/usr ] || mkdir --mode=0755 "$tmp"/usr
+       [ -d "$tmp"/usr/local ] || mkdir --mode=0755 "$tmp"/usr/local
+       [ -d "$tmp"/usr/local/bin ] || mkdir --mode=0755 "$tmp"/usr/local/bin
+
+       echo "Downloading ruuvitag-listener from URL: $RT_LISTENER_URL"
+       curl -Lf# "$RT_LISTENER_URL" > "$tmp"/usr/local/bin/ruuvitag-listener
+       chmod 755 "$tmp"/usr/local/bin/ruuvitag-listener
+}
+
+configure_syslog() {
+	mkdir -p "$tmp"/etc/conf.d
+	makefile root:root 0644 "$tmp"/etc/conf.d/syslog <<EOF
+# -t         Strip client-generated timestamps
+# -s SIZE    Max size (KB) before rotation (default 200KB, 0=off)
+# -b N       N rotated logs to keep (default 1, max 99, 0=purge)
+
+SYSLOGD_OPTS="-t -s 512 -b 10"
+EOF
+}
+
+tmp="$(mktemp -d)"
+trap cleanup EXIT
+
+mkdir -p "$tmp"/etc
+makefile root:root 0644 "$tmp"/etc/hostname <<EOF
+rpi-ruuvi
+EOF
+
+configure_network
+configure_wifi
+set_hostname_with_udhcpc
+configure_installed_packages
+configure_chrony_as_client
+configure_syslog
+add_ssh_key
+configure_init_scripts
+install_ruuvitag_listener
+install_overlays
+
+echo "Creating overlay file $hostname.apkovl.tar.gz ..."
+tar -C "$tmp" -c etc root usr/local | gzip -9n > "$hostname.apkovl.tar.gz"

--- a/scripts/mkimg.rpi-ruuvi.sh
+++ b/scripts/mkimg.rpi-ruuvi.sh
@@ -1,0 +1,31 @@
+rpi_ruuvi_gen_usercfg() {
+	cat <<-EOF
+	gpu_mem=16
+EOF
+}
+
+build_rpi_ruuvi_usercfg() {
+	rpi_ruuvi_gen_usercfg > "${DESTDIR}"/usercfg.txt
+}
+
+section_rpi_ruuvi_usercfg() {
+	[ "$PROFILE" = "rpi_ruuvi" ] || return 0
+	build_section rpi_ruuvi_usercfg "$( rpi_ruuvi_gen_usercfg | checksum )"
+}
+
+profile_rpi_ruuvi() {
+	profile_rpi
+	kernel_cmdline="console=tty1 $CMDLINE_EXTRA"
+	apks="$apks
+		chrony
+		openssh-server
+		prometheus-node-exporter
+		wireless-tools
+		wpa_supplicant
+		atop
+		bluez
+		tmux
+		pv
+"
+	apkovl="genapkovl-rpi-ruuvi.sh"
+}


### PR DESCRIPTION
The ruuvitag-listener command installed to `/usr/local/bin` is an
armhf build of lautis' [ruuvitag-listener].  The script to forward
the InfluxDB line protocol data to a server server is not included
in the image.  It's really rough and not 100% reliable.  (That's also
why the tmux and pv packages are included in the image.)

Planning to decommission InfluxDB at some point and may fork
ruuvitag-listener or switch to a different ruuvitag-to-metrics
utility.

[ruuvitag-listener]: https://github.com/lautis/ruuvitag-listener