### PR TITLE
rpi-k0s-controller: install and enable node-exporter

### DIFF
--- a/scripts/genapkovl-k0s-node.sh
+++ b/scripts/genapkovl-k0s-node.sh
@@ -8,6 +8,10 @@ basedir="$(dirname "$0")"
 [ "$basedir" = "/bin" ] && basedir="./scripts" # shellspec workaround for $0 handling
 . "$basedir"/shared.sh
 
+is_controller() {
+	test "$HL_HOSTNAME" = "k0s-controller"
+}
+
 k0s_arch() {
 	case "$ARCH" in
 		x86_64) echo "amd64" ;;
@@ -32,6 +36,9 @@ configure_installed_packages() {
 		iptables \
 		nfs-utils \
 
+	if is_controller; then
+		apk_add prometheus-node-exporter
+	fi
 }
 
 configure_network() {
@@ -73,6 +80,10 @@ configure_init_scripts() {
 	rc_add chronyd default
 	rc_add sshd default
 	rc_add cgroups default
+
+	if is_controller; then
+		rc_add node-exporter default
+	fi
 }
 
 install_k0s() {

--- a/scripts/mkimg.rpi-k0s-controller.sh
+++ b/scripts/mkimg.rpi-k0s-controller.sh
@@ -19,6 +19,16 @@ profile_rpi_k0s_controller() {
     profile_abbrev="k0s_controller"
     title="Alpine for k0s controller node (RPi)"
     desc="Standard Alpine image ready to be provisioned as k0s controller node, likely with k0sctl.  Runs from RAM."
-    apks="$apks chrony openssh-server findutils coreutils curl iptables nfs-utils atop"
+    apks="$apks
+        chrony
+        openssh-server
+        findutils
+        coreutils
+        curl
+        iptables
+        nfs-utils
+        atop
+        prometheus-node-exporter
+    "
     apkovl="genapkovl-k0s-node.sh"
 }


### PR DESCRIPTION
Run the Prometheus node-exporter on k0s controller images.