### PR TITLE
k0s-controller: publish scheduler and controller-manager metrics

### DIFF
--- a/k0s/cluster.yaml.in
+++ b/k0s/cluster.yaml.in
@@ -8,6 +8,8 @@ spec:
       address: {{ .Env.K0S_CONTROLLER_IP }}
       user: root
     role: controller
+    installFlags:
+    - --enable-metrics-scraper
   {{/* Must be a more concise way, but `(net.ParseIPPrefix ...).Range` seemed to be a dead end. */}}
   # 172.22.18.16/29 hosts
 {{- range $worker_ip := slice "172.22.18.17" "172.22.18.18" "172.22.18.19" "172.22.18.20" "172.22.18.21" "172.22.18.22" }}


### PR DESCRIPTION
Scrape kube-scheduler and kube-controller-manager, which are not running
as pods, and push their metrics into a `k0s-pushgateway` pod running in
the `k0s-system` namespace that exports those metrics for scraping by
prometheus inside the cluster.

Docs:
https://docs.k0sproject.io/v1.24.3+k0s.0/system-monitoring/