### PR TITLE
k0s, k0s-worker, rpi-k0s-controller: upgrade from version 1.24.3.k0s.0 to 1.25.2+k0s.0

### DIFF
--- a/k0s/cluster.yaml.in
+++ b/k0s/cluster.yaml.in
@@ -17,7 +17,7 @@ spec:
     role: worker
 {{- end }}
   k0s:
-    version: 1.24.3+k0s.0
+    version: 1.25.2+k0s.0
     config:
       apiVersion: k0s.k0sproject.io/v1beta1
       kind: Cluster

--- a/scripts/genapkovl-k0s-node.sh
+++ b/scripts/genapkovl-k0s-node.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 
-K0S_VER=1.24.3+k0s.0
+K0S_VER=1.25.2+k0s.0
 
 hostname="$1"
 


### PR DESCRIPTION
Release notes:
https://github.com/k0sproject/k0s/releases/tag/v1.25.2%2Bk0s.0
https://github.com/k0sproject/k0s/releases/tag/v1.24.6%2Bk0s.0