### PR TITLE
k0s: upgrade Argo CD from 2.4.11 to 2.4.12

### DIFF
--- a/k0s/Makefile
+++ b/k0s/Makefile
@@ -1,4 +1,4 @@
-ARGOCD_VER := 2.4.11
+ARGOCD_VER := 2.4.12
 ARGOCD_CLI_URL := https://github.com/argoproj/argo-cd/releases/download/v$(ARGOCD_VER)/argocd-linux-amd64
 
 K0SCTL_VER := 0.13.0

--- a/k0s/cluster.yaml.in
+++ b/k0s/cluster.yaml.in
@@ -40,11 +40,11 @@ spec:
             - name: argo-cd
               namespace: argocd
               chartname: argo-repo/argo-cd
-              version: "4.10.9"
+              version: "5.5.7"
               values: |
                 global:
                   image:
-                    tag: "v2.4.11"
+                    tag: "v2.4.12"
                 dex:
                   enabled: false
                 server:


### PR DESCRIPTION
Changelog at:
https://github.com/argoproj/argo-cd/blob/master/CHANGELOG.md

Release notes at:
https://github.com/argoproj/argo-cd/releases/tag/v2.4.12