### PR TITLE
k0s: update k0sctl from version 0.14.0 to 0.15.0

### DIFF
--- a/k0s/Makefile
+++ b/k0s/Makefile
@@ -1,7 +1,7 @@
 ARGOCD_VER := 2.5.4
 ARGOCD_CLI_URL := https://github.com/argoproj/argo-cd/releases/download/v$(ARGOCD_VER)/argocd-linux-amd64
 
-K0SCTL_VER := 0.14.0
+K0SCTL_VER := 0.15.0
 K0SCTL_URL := https://github.com/k0sproject/k0sctl/releases/download/v$(K0SCTL_VER)/k0sctl-linux-x64
 
 mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))

--- a/scripts/genapkovl-k0s-node.sh
+++ b/scripts/genapkovl-k0s-node.sh
@@ -80,6 +80,7 @@ configure_init_scripts() {
 	rc_add chronyd default
 	rc_add sshd default
 	rc_add cgroups default
+	rc_add machine-id default
 
 	if is_controller; then
 		rc_add node-exporter default


### PR DESCRIPTION
Run `/etc/init.d/machine-id` on startup because k0sctl now performs a uniqueness check when building the cluster:
https://github.com/k0sproject/k0sctl/pull/435

Release notes:
https://github.com/k0sproject/k0sctl/releases/tag/v0.15.0