### PR TITLE
update to actions/checkout@v3 to fix warnings

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: install linters
         run: sudo apt-get install -y shellcheck
@@ -36,7 +36,7 @@ jobs:
           - rpi-snapcast-client-armhf
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: build ${{ matrix.image }}
         env:


### PR DESCRIPTION
Fixes warning:

> Node.js 12 actions are deprecated. Please update the following
> actions to use Node.js 16: actions/checkout@v2. For more
> information see:
> https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.