### PR TITLE
k0s, k0s-worker, rpi-k0s-controller: use Cilium CNI plugin

### DIFF
--- a/k0s/Makefile
+++ b/k0s/Makefile
@@ -1,6 +1,9 @@
 ARGOCD_VER := 2.5.4
 ARGOCD_CLI_URL := https://github.com/argoproj/argo-cd/releases/download/v$(ARGOCD_VER)/argocd-linux-amd64
 
+CILIUM_CLI_VER := 0.12.12
+CILIUM_CLI_URL := https://github.com/cilium/cilium-cli/releases/download/v$(CILIUM_CLI_VER)/cilium-linux-amd64.tar.gz
+
 K0SCTL_VER := 0.15.0
 K0SCTL_URL := https://github.com/k0sproject/k0sctl/releases/download/v$(K0SCTL_VER)/k0sctl-linux-x64
 
@@ -14,6 +17,7 @@ kubeconfig := cluster_kubeconf.yaml
 	add_controller_host \
 	provision_controller \
 	ssh_controller \
+	install_cilium_cli \
 	install_k0sctl \
 	build_cluster \
 	argocd_cli_install \
@@ -45,6 +49,9 @@ provision_controller:
 
 ssh_controller:
 	ssh root@$(shell cd $(mkfile_dir); ./controller_ip.sh)
+
+install_cilium_cli:
+	@[ -e /usr/local/bin/cilium ] || (curl -o /tmp/cilium.tgz -Lf $(CILIUM_CLI_URL) && sudo tar -C /usr/local/bin -xzf /tmp/cilium.tgz cilium && cilium version)
 
 install_k0sctl:
 	@[ -e /usr/local/bin/k0sctl ] || (curl -o /tmp/k0sctl -Lf $(K0SCTL_URL) && chmod 0755 /tmp/k0sctl && sudo mv /tmp/k0sctl /usr/local/bin/ && k0sctl version)

--- a/k0s/cluster.yaml.in
+++ b/k0s/cluster.yaml.in
@@ -1,7 +1,7 @@
 apiVersion: k0sctl.k0sproject.io/v1beta1
 kind: Cluster
 metadata:
-  name: k0s-cluster
+  name: k0s-lab
 spec:
   hosts:
   - ssh:
@@ -24,8 +24,12 @@ spec:
       apiVersion: k0s.k0sproject.io/v1beta1
       kind: Cluster
       metadata:
-        name: k0s-cluster
+        name: k0s-lab
       spec:
+        network:
+          kubeProxy:
+            disabled: true
+          provider: custom
         storage:
           type: kine
 # Use default setup of SQLite
@@ -36,12 +40,27 @@ spec:
             repositories:
             - name: argo-repo
               url: https://argoproj.github.io/argo-helm
+            - name: cilium
+              url: https://helm.cilium.io
             charts:
-            - name: argo-cd
+            - name: a-cilium # a- prefix to run first, before argocd which cannot helm install without a CNI plugin
+              namespace: kube-system
+              chartname: cilium/cilium
+              version: "1.12.6"
+              values: |
+                k8sServiceHost: {{ .Env.K0S_CONTROLLER_IP }}
+                k8sServicePort: 6443
+                encryption:
+                  nodeEncryption: false
+                kubeProxyReplacement: "strict"
+                kubeProxyReplacementHealthzBindAddr: "0.0.0.0:10256"
+                tunnel: vxlan
+            - name: z-argo-cd
               namespace: argocd
               chartname: argo-repo/argo-cd
               version: "5.16.2"
               values: |
+                fullnameOverride: argocd
                 global:
                   image:
                     tag: "v2.5.4"

--- a/scripts/genapkovl-k0s-node.sh
+++ b/scripts/genapkovl-k0s-node.sh
@@ -91,7 +91,7 @@ add_prepare_for_k8s_init_script() {
 	if is_controller; then
 		worker_only_calls=""
 	else
-		worker_only_calls="share_sys"
+		worker_only_calls="$(printf "share_sys\n\tsetup_for_cilium")"
 	fi
 
 	mkdir -p "$tmp"/etc/init.d
@@ -127,6 +127,17 @@ share_sys() {
 	einfo "Sharing /sys with containers for node-exporter"
 	mount --make-shared /
 	mount --make-shared /sys
+}
+
+setup_for_cilium() {
+	einfo "Mounting /sys/fs/bpf and sharing with containers for Cilium"
+	mount bpffs -t bpf /sys/fs/bpf
+	mount --make-shared /sys/fs/bpf
+
+	einfo "Creating /run/cilium/cgroupv2 and sharing with containers for Cilium"
+	mkdir -p /run/cilium/cgroupv2
+	mount -t cgroup2 none /run/cilium/cgroupv2
+	mount --make-shared /run/cilium/cgroupv2
 }
 
 start() {


### PR DESCRIPTION
Had trouble with the k0s default of kube-router where prometheus could not connect to TCP 19115 on the
blackbox-exporter pod, despite network policies in place to allow it.

Began tracing the iptables rule chains, bridges, and other network magic to find the problem and lost patience before finding the root cause.

In local VM testing, Cilium seems to work well and has some built-in diagnostic tools if the connectivity problems return.