### PR TITLE
k0s: upgrade Argo CD from 2.5.4 to 2.5.15

### DIFF
--- a/k0s/Makefile
+++ b/k0s/Makefile
@@ -1,4 +1,4 @@
-ARGOCD_VER := 2.5.4
+ARGOCD_VER := 2.5.15
 ARGOCD_CLI_URL := https://github.com/argoproj/argo-cd/releases/download/v$(ARGOCD_VER)/argocd-linux-amd64
 
 CILIUM_CLI_VER := 0.12.12

--- a/k0s/cluster.yaml.in
+++ b/k0s/cluster.yaml.in
@@ -58,12 +58,12 @@ spec:
             - name: z-argo-cd
               namespace: argocd
               chartname: argo-repo/argo-cd
-              version: "5.16.2"
+              version: "5.19.15"
               values: |
                 fullnameOverride: argocd
                 global:
                   image:
-                    tag: "v2.5.4"
+                    tag: "v2.5.15"
                 dex:
                   enabled: false
                 server:


### PR DESCRIPTION
Release notes at:
https://github.com/argoproj/argo-cd/releases/tag/v2.5.15