### PR TITLE
k0s: upgrade Cilium from 1.12.6 to 1.13.2

### DIFF
--- a/k0s/cluster.yaml.in
+++ b/k0s/cluster.yaml.in
@@ -46,7 +46,7 @@ spec:
             - name: a-cilium # a- prefix to run first, before argocd which cannot helm install without a CNI plugin
               namespace: kube-system
               chartname: cilium/cilium
-              version: "1.12.6"
+              version: "1.13.2"
               values: |
                 k8sServiceHost: {{ .Env.K0S_CONTROLLER_IP }}
                 k8sServicePort: 6443


### PR DESCRIPTION
Release notes at:
https://github.com/cilium/cilium/releases/tag/v1.13.2

Changelog:
https://github.com/cilium/cilium/blob/v1.13.2/CHANGELOG.md