### PR TITLE
fix `vpn_routes` script for Alpine 3.19

### DIFF
--- a/scripts/genapkovl-rpi-firewall.sh
+++ b/scripts/genapkovl-rpi-firewall.sh
@@ -166,17 +166,16 @@ add_route() {
 	local vlan_id="\$2"
 	local source_ip="\$3"
 
-	grep -q "\$table_name" /etc/iproute2/rt_tables || echo "\$vlan_id \$table_name" >> /etc/iproute2/rt_tables
-	ip -4 rule add iif "eth0.\$vlan_id" table "\$table_name"
-	ip -4 route add default via "\$source_ip" dev wg0 table "\$table_name"
+	ip -4 rule add iif "eth0.\$vlan_id" table "\$vlan_id"
+	ip -4 route add default via "\$source_ip" dev wg0 table "\$vlan_id"
 }
 
 del_route() {
 	local table_name="\$1"
 	local vlan_id="\$2"
 
-	ip -4 route flush table "\$table_name" || true
-	ip -4 rule del iif "eth0.\$vlan_id" table "\$table_name" || true
+	ip -4 route flush table "\$vlan_id" || true
+	ip -4 rule del iif "eth0.\$vlan_id" table "\$vlan_id" || true
 }
 
 case "\$1" in


### PR DESCRIPTION
After PR #81 to upgrade from Alpine 3.18 to 3.19, the `vpn_routes` script would fail with:

    rpi-fw:~# /usr/local/bin/vpn_routes add k8s_net 118 "10.201.196.2"
    grep: /etc/iproute2/rt_tables: No such file or directory
    /usr/local/bin/vpn_routes: line 12: can't create /etc/iproute2/rt_tables: nonexistent directory

Likely caused by this change in 3.19:

* iptables-nft is now the [default] iptables backend.

Tweak the script to eliminate the `rt_tables` reference that broke.

[default]: https://gitlab.alpinelinux.org/alpine/aports/-/commit/f87a191922955bcf5c5f3fc66a425263a4588d48