### PR TITLE
update all images to Alpine 3.20

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 export ACI_REPO := https://github.com/alpinelinux/alpine-chroot-install.git
 export ACI_TAG := v0.14.0
-export ALPINE_VERSION := 3.19
+export ALPINE_VERSION := 3.20
 export APORTS_REPO := https://github.com/alpinelinux/aports.git
 export BUILD_USER := imagebuilder
 export WORK_DIR := bootstrap

--- a/Makefile.images
+++ b/Makefile.images
@@ -76,7 +76,7 @@ chroot: clone-aci populate-shared
 		-d $(abspath $(WORK_DIR))/$(ARCH) \
 		-i $(abspath $(WORK_DIR))/shared \
 		-k "ARCH CI QEMU_EMULATOR HL_.*" \
-		-p "abuild apk-tools alpine-conf busybox fakeroot sudo squashfs-tools mkinitfs grub-efi mtools xorriso"
+		-p "abuild apk-tools alpine-conf busybox curl fakeroot sudo squashfs-tools mkinitfs grub-efi mtools xorriso"
 
 build-user: chroot
 	# add non-root user to build images


### PR DESCRIPTION
`curl` is no longer installed by default so add it for build-time downloads.