### PR TITLE
disable the k0s-working builds for amd64 in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,8 +54,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - image: k0s-worker
-            platform: linux/amd64
+# The k0s-worker build on amd64 is currently failing with:
+#
+#     Unable to find image 'alpine-builder:3.21-latest' locally
+#     docker: Error response from daemon: pull access denied for alpine-builder, repository does not exist or may require 'docker login': denied: requested access to the resource is denied.
+#     See 'docker run --help'.
+#     error: Recipe `abuild-keygen` failed on line 74 with exit code 125
+#     Error: Process completed with exit code 125.
+#          - image: k0s-worker
+#            platform: linux/amd64
           - image: rpi-basic
             platform: linux/arm/v6
           - image: rpi-basic


### PR DESCRIPTION
The GH docker configuration needs work to get everything working again after PR #85. For now, just disable the failing k0s-worker build that's failing to get back to green for most images.